### PR TITLE
Remove Lab routing from main.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-import { BrowserRouter } from "react-router-dom";
 import {
   // Blueprint/Terminal Theme Components
   TerminalNavbar,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,32 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import {RouterProvider, createBrowserRouter} from 'react-router-dom'
 import './index.css'
 import App from './App'
-import LabMain from './components/LabMain'
-import LabCourse from './components/LabMain/LabCourse'
-import LabDay from './components/LabMain/LabDay'
-export const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <App />,
-  },
-  {
-    path: "/lab",
-    element: <LabMain />,
-  },
-  {
-    path: "/lab/course/:courseId",
-    element: <LabCourse />,
-  },
-  {
-    path: "/lab/course/:courseId/:dayId",
-    element: <LabDay />,
-  }
-]);
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <App />
   </React.StrictMode>
 );


### PR DESCRIPTION
- Removed Lab component imports and routing from main.jsx
- Simplified to render App directly without React Router
- Removed BrowserRouter import from App.jsx (no longer needed)
- Fixes import errors after Lab section removal