### PR TITLE
Add terminal window wrapper to tech skills section

### DIFF
--- a/src/features/tech/TechTerminal.jsx
+++ b/src/features/tech/TechTerminal.jsx
@@ -48,102 +48,117 @@ const TechTerminal = () => {
         Tech stack powering enterprise software, robotics automation, and AI-driven solutions.
       </motion.p>
 
-      {/* Bento Grid Layout - Unique Floating Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-auto">
-        {Object.entries(techCategories).map(([key, { label, techs, color }], catIndex) => (
-          <motion.div
-            key={key}
-            variants={fadeIn("up", "spring", 0.2 + catIndex * 0.1, 0.75)}
-            className={`
-              bento-box group relative overflow-hidden
-              ${key === 'backend' ? 'lg:col-span-2' : ''}
-              ${key === 'learning' ? 'md:col-span-2 lg:col-span-1' : ''}
-            `}
-          >
-            {/* Animated Background Gradient */}
-            <div className={`absolute inset-0 opacity-0 group-hover:opacity-5 transition-opacity duration-500 bg-gradient-to-br ${color.replace('text-', 'from-')} to-transparent`} />
+      {/* Terminal Window Wrapper */}
+      <motion.div
+        variants={fadeIn("up", "spring", 0.2, 0.75)}
+        className="relative border border-white/10 rounded-xl overflow-hidden bg-black/30 backdrop-blur-sm shadow-2xl"
+      >
+        {/* Terminal Header */}
+        <div className="bg-tertiary border-b border-white/10 px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {/* Terminal Buttons */}
+            <div className="flex gap-2">
+              <div className="w-3 h-3 rounded-full bg-red-500/80 hover:bg-red-500 transition-colors cursor-pointer" />
+              <div className="w-3 h-3 rounded-full bg-yellow-500/80 hover:bg-yellow-500 transition-colors cursor-pointer" />
+              <div className="w-3 h-3 rounded-full bg-green-500/80 hover:bg-green-500 transition-colors cursor-pointer" />
+            </div>
+            {/* Terminal Title */}
+            <span className="ml-3 text-secondary/70 font-mono text-sm">
+              tech_skills.sh
+            </span>
+          </div>
+          <div className="flex items-center gap-2 text-secondary/50 text-xs font-mono">
+            <span className="hidden sm:inline">zsh</span>
+            <span>●</span>
+            <span className="hidden sm:inline">5 modules</span>
+          </div>
+        </div>
 
-            {/* Card Content */}
-            <div className="relative p-6 h-full flex flex-col">
-              {/* Category Header */}
-              <div className="flex items-center gap-3 mb-4">
-                <div className={`w-1 h-8 ${color.replace('text-', 'bg-')} rounded-full`} />
-                <div>
-                  <h3 className={`${color} font-mono text-sm font-semibold tracking-wider`}>
-                    {label.toUpperCase()}
-                  </h3>
-                  <div className="flex items-center gap-2 mt-1">
-                    <span className="text-secondary/50 text-xs font-mono">{techs.length} techs</span>
-                    <div className={`h-px w-8 ${color.replace('text-', 'bg-')} opacity-30`} />
+        {/* Command Prompt Line */}
+        <div className="bg-black/20 border-b border-white/5 px-6 py-3 font-mono text-sm">
+          <span className="text-terminal-green">➜</span>
+          <span className="text-blueprint ml-2">~/portfolio</span>
+          <span className="text-secondary/50 ml-2">cat tech_skills.sh</span>
+          <span className="animate-pulse ml-1">▊</span>
+        </div>
+
+        {/* Bento Grid Layout - Terminal Style */}
+        <div className="p-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-auto">
+          {Object.entries(techCategories).map(([key, { label, techs, color }], catIndex) => (
+            <motion.div
+              key={key}
+              variants={fadeIn("up", "spring", 0.2 + catIndex * 0.1, 0.75)}
+              className={`
+                bento-box group relative overflow-hidden
+                ${key === 'backend' ? 'lg:col-span-2' : ''}
+                ${key === 'learning' ? 'md:col-span-2 lg:col-span-1' : ''}
+              `}
+            >
+              {/* Animated Background Gradient */}
+              <div className={`absolute inset-0 opacity-0 group-hover:opacity-5 transition-opacity duration-500 bg-gradient-to-br ${color.replace('text-', 'from-')} to-transparent`} />
+
+              {/* Card Content */}
+              <div className="relative p-6 h-full flex flex-col">
+                {/* Category Header with Terminal Style */}
+                <div className="flex items-center gap-3 mb-4">
+                  <div className={`w-1 h-8 ${color.replace('text-', 'bg-')} rounded-full`} />
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className={`${color} text-xs font-mono`}>$</span>
+                      <h3 className={`${color} font-mono text-sm font-semibold tracking-wider`}>
+                        {label.toUpperCase()}
+                      </h3>
+                    </div>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className="text-secondary/50 text-xs font-mono">[{techs.length} techs]</span>
+                      <div className={`h-px w-8 ${color.replace('text-', 'bg-')} opacity-30`} />
+                    </div>
                   </div>
                 </div>
+
+                {/* Technologies as Floating Pills */}
+                <div className="flex flex-wrap gap-2">
+                  {techs.map((tech, index) => (
+                    <motion.div
+                      key={tech}
+                      initial={{ opacity: 0, scale: 0.8 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      transition={{ delay: 0.3 + catIndex * 0.1 + index * 0.05 }}
+                      whileHover={{ scale: 1.05, y: -2 }}
+                      className={`
+                        relative px-3 py-1.5 rounded
+                        bg-tertiary/50 backdrop-blur-sm
+                        border border-white/10
+                        hover:border-${color.replace('text-', '')}/50
+                        transition-all duration-300
+                        cursor-pointer
+                        group/pill
+                      `}
+                    >
+                      <span className={`${color.replace('text-', 'text-')}/70 text-sm font-mono group-hover/pill:${color} transition-colors`}>
+                        {tech}
+                      </span>
+
+                      {/* Hover glow effect */}
+                      <div className={`absolute inset-0 rounded opacity-0 group-hover/pill:opacity-20 transition-opacity ${color.replace('text-', 'bg-')} blur-md -z-10`} />
+                    </motion.div>
+                  ))}
+                </div>
+
+                {/* Corner Accent */}
+                <div className={`absolute top-0 right-0 w-16 h-16 ${color.replace('text-', 'bg-')} opacity-5 blur-2xl rounded-full -translate-y-8 translate-x-8 group-hover:opacity-10 transition-opacity`} />
               </div>
+            </motion.div>
+          ))}
+        </div>
 
-              {/* Technologies as Floating Pills */}
-              <div className="flex flex-wrap gap-2">
-                {techs.map((tech, index) => (
-                  <motion.div
-                    key={tech}
-                    initial={{ opacity: 0, scale: 0.8 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={{ delay: 0.3 + catIndex * 0.1 + index * 0.05 }}
-                    whileHover={{ scale: 1.05, y: -2 }}
-                    className={`
-                      relative px-3 py-1.5 rounded-full
-                      bg-tertiary/50 backdrop-blur-sm
-                      border border-white/5
-                      hover:border-white/20
-                      transition-all duration-300
-                      cursor-pointer
-                      group/pill
-                    `}
-                  >
-                    <span className="text-white/90 text-sm font-sans group-hover/pill:text-white transition-colors">
-                      {tech}
-                    </span>
-
-                    {/* Hover glow effect */}
-                    <div className={`absolute inset-0 rounded-full opacity-0 group-hover/pill:opacity-20 transition-opacity ${color.replace('text-', 'bg-')} blur-md -z-10`} />
-                  </motion.div>
-                ))}
-              </div>
-
-              {/* Corner Accent */}
-              <div className={`absolute top-0 right-0 w-16 h-16 ${color.replace('text-', 'bg-')} opacity-5 blur-2xl rounded-full -translate-y-8 translate-x-8 group-hover:opacity-10 transition-opacity`} />
-            </div>
-          </motion.div>
-        ))}
-      </div>
-
-      {/* Tech Icon Grid - Minimal Cards */}
-      <motion.div
-        variants={fadeIn("up", "spring", 0.9, 0.75)}
-        className="mt-8 grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 gap-3"
-      >
-        {technologies.map((tech, index) => (
-          <motion.div
-            key={tech.name}
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ delay: 1 + index * 0.03 }}
-            className="group relative"
-          >
-            <div className="aspect-square bento-box p-3 flex items-center justify-center hover:scale-110 transition-all duration-300 hover:shadow-blueprint">
-              <img
-                src={tech.icon}
-                alt={tech.name}
-                className="w-full h-full object-contain opacity-60 group-hover:opacity-100 transition-opacity filter grayscale group-hover:grayscale-0"
-              />
-
-              {/* Tooltip */}
-              <div className="absolute -bottom-10 left-1/2 -translate-x-1/2 bg-tertiary border border-blueprint/50 px-3 py-1.5 rounded text-xs text-blueprint-light whitespace-nowrap opacity-0 group-hover:opacity-100 transition-all duration-300 pointer-events-none z-20 shadow-lg">
-                {tech.name}
-                <div className="absolute -top-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-tertiary border-l border-t border-blueprint/50 rotate-45" />
-              </div>
-            </div>
-          </motion.div>
-        ))}
+        {/* Terminal Footer */}
+        <div className="bg-black/20 border-t border-white/5 px-6 py-2 font-mono text-xs text-secondary/50 flex items-center justify-between">
+          <span>5 categories loaded successfully</span>
+          <span className="hidden sm:inline">Press ESC to exit</span>
+        </div>
       </motion.div>
+
 
       {/* Info Cards - Updated */}
       <div className="mt-10 grid grid-cols-1 md:grid-cols-3 gap-4">


### PR DESCRIPTION
- Remove tech icon grid to streamline the view
- Add terminal window wrapper with header, command prompt, and footer
- Include terminal buttons (red/yellow/green) and title bar showing 'tech_skills.sh'
- Add animated command prompt line with blinking cursor
- Enhance bento cards with terminal styling ($ prefix, monospace fonts, square borders)
- Add terminal footer with status message
- Maintain bento-grid layout with improved terminal aesthetics