### PR TITLE
Remove terminal styling and unify with modern card design

### DIFF
--- a/src/components/layout/TerminalNavbar.jsx
+++ b/src/components/layout/TerminalNavbar.jsx
@@ -3,14 +3,13 @@ import { styles } from "../../styles";
 
 const TerminalNavbar = () => {
   const [scrolled, setScrolled] = useState(false);
-  const [currentPath, setCurrentPath] = useState("/home/jewel");
 
   const navItems = [
-    { id: "about", title: "about", path: "/about" },
-    { id: "project", title: "projects", path: "/projects" },
-    { id: "lab", title: "lab", path: "/lab" },
-    { id: "work", title: "experience", path: "/experience" },
-    { id: "contact", title: "contact", path: "/contact" },
+    { id: "about", title: "About" },
+    { id: "project", title: "Projects" },
+    { id: "tech", title: "Tech Skills" },
+    { id: "work", title: "Experience" },
+    { id: "contact", title: "Contact" },
   ];
 
   useEffect(() => {
@@ -22,8 +21,7 @@ const TerminalNavbar = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const scrollToElement = (id, path) => {
-    setCurrentPath(path);
+  const scrollToElement = (id) => {
     setTimeout(() => {
       const element = document.getElementById(id);
       if (element) {
@@ -33,46 +31,36 @@ const TerminalNavbar = () => {
   };
 
   const scrollToTop = () => {
-    setCurrentPath("/home/jewel");
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   return (
     <nav
       className={`${styles.paddingX} w-full flex items-center py-4 fixed top-0 z-20 transition-all duration-300 ${
-        scrolled ? "bg-primary/95 backdrop-blur-sm border-b border-blueprint/20" : "bg-transparent"
+        scrolled ? "bg-primary/95 backdrop-blur-md border-b border-white/10" : "bg-transparent"
       }`}
     >
       <div className="w-full flex justify-between items-center max-w-7xl mx-auto">
-        {/* Terminal-style branding */}
+        {/* Modern branding */}
         <div
           onClick={scrollToTop}
-          className="flex items-center gap-3 cursor-pointer group"
+          className="cursor-pointer group"
         >
-          <div className="flex items-center gap-1">
-            <span className="text-terminal-green font-mono text-lg">$</span>
-            <span className="text-blueprint font-mono text-lg group-hover:text-blueprint-light transition-colors">
-              jewel@portfolio
-            </span>
-            <span className="text-secondary font-mono text-lg">:</span>
-            <span className="text-white font-mono text-lg">~</span>
-          </div>
+          <h1 className="text-xl font-bold bg-gradient-to-r from-blueprint-light via-terminal-green to-blueprint bg-clip-text text-transparent group-hover:opacity-80 transition-opacity">
+            Jewel Nath
+          </h1>
         </div>
 
-        {/* Desktop Navigation - Terminal Style */}
-        <div className="hidden md:flex items-center gap-6">
+        {/* Desktop Navigation - Modern Style */}
+        <div className="hidden md:flex items-center gap-8">
           {navItems.map((item) => (
             <button
               key={item.id}
-              onClick={() => scrollToElement(item.id, item.path)}
-              className="font-mono text-sm text-secondary hover:text-blueprint transition-colors flex items-center gap-2 group"
+              onClick={() => scrollToElement(item.id)}
+              className="text-sm text-secondary hover:text-white transition-colors relative group"
             >
-              <span className="text-terminal-dim group-hover:text-terminal-green transition-colors">
-                cd
-              </span>
-              <span className="group-hover:text-blueprint-light transition-colors">
-                {item.title}
-              </span>
+              <span>{item.title}</span>
+              <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-gradient-to-r from-blueprint to-terminal-green group-hover:w-full transition-all duration-300"></span>
             </button>
           ))}
 
@@ -81,27 +69,15 @@ const TerminalNavbar = () => {
             href="/Jewel Resume.pdf"
             target="_blank"
             rel="noopener noreferrer"
-            className="font-mono text-sm border border-blueprint text-blueprint px-4 py-2 rounded hover:bg-blueprint/10 hover:shadow-terminal transition-all flex items-center gap-2"
+            className="text-sm border border-blueprint text-blueprint px-4 py-2 rounded-lg hover:bg-blueprint/10 transition-all"
           >
-            <span>cat</span>
-            <span>resume.pdf</span>
+            Resume
           </a>
         </div>
 
         {/* Mobile Menu */}
         <MobileMenu navItems={navItems} scrollToElement={scrollToElement} />
       </div>
-
-      {/* Current Path Indicator (optional) */}
-      {scrolled && (
-        <div className="absolute bottom-0 left-0 right-0 px-6 pb-1">
-          <div className="max-w-7xl mx-auto">
-            <div className="font-mono text-xs text-blueprint/50">
-              {currentPath}
-            </div>
-          </div>
-        </div>
-      )}
     </nav>
   );
 };
@@ -112,35 +88,34 @@ const MobileMenu = ({ navItems, scrollToElement }) => {
 
   return (
     <div className="md:hidden">
-      {/* Hamburger Button - Terminal Style */}
+      {/* Hamburger Button - Modern Style */}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="font-mono text-blueprint text-xl focus:outline-none"
+        className="text-white focus:outline-none p-2"
       >
-        {isOpen ? "[x]" : "[≡]"}
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          {isOpen ? (
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          ) : (
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          )}
+        </svg>
       </button>
 
       {/* Mobile Dropdown */}
       {isOpen && (
-        <div className="absolute top-full right-0 mt-2 mx-4 terminal-window min-w-[200px]">
-          <div className="terminal-header">
-            <div className="terminal-dot red" />
-            <div className="terminal-dot yellow" />
-            <div className="terminal-dot green" />
-          </div>
-
+        <div className="absolute top-full right-0 mt-2 mx-4 bg-tertiary/95 backdrop-blur-md border border-white/10 rounded-lg shadow-2xl min-w-[200px] overflow-hidden">
           <div className="p-4 space-y-3">
             {navItems.map((item) => (
               <button
                 key={item.id}
                 onClick={() => {
-                  scrollToElement(item.id, item.path);
+                  scrollToElement(item.id);
                   setIsOpen(false);
                 }}
-                className="w-full text-left font-mono text-sm text-secondary hover:text-blueprint transition-colors flex items-center gap-2"
+                className="w-full text-left text-sm text-secondary hover:text-white transition-colors py-2"
               >
-                <span className="text-terminal-dim">$</span>
-                <span>cd {item.title}</span>
+                {item.title}
               </button>
             ))}
 
@@ -148,10 +123,9 @@ const MobileMenu = ({ navItems, scrollToElement }) => {
               href="/Jewel Resume.pdf"
               target="_blank"
               rel="noopener noreferrer"
-              className="w-full text-left font-mono text-sm text-secondary hover:text-blueprint transition-colors flex items-center gap-2 pt-3 border-t border-blueprint/20"
+              className="block w-full text-left text-sm text-blueprint hover:text-blueprint-light transition-colors py-2 pt-3 border-t border-white/10"
             >
-              <span className="text-terminal-dim">$</span>
-              <span>cat resume.pdf</span>
+              Resume
             </a>
           </div>
         </div>

--- a/src/features/contact/ContactTerminal.jsx
+++ b/src/features/contact/ContactTerminal.jsx
@@ -14,19 +14,11 @@ const ContactTerminal = () => {
   });
 
   const [loading, setLoading] = useState(false);
-  const [terminalOutput, setTerminalOutput] = useState([
-    { text: "Welcome to Contact Terminal v1.0", type: "info" },
-    { text: "Type your message below to get in touch with Jewel.", type: "info" },
-    { text: "─────────────────────────────────────────────────", type: "divider" },
-  ]);
+  const [statusMessage, setStatusMessage] = useState({ text: "", type: "" });
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setForm({ ...form, [name]: value });
-  };
-
-  const addToTerminal = (text, type = "normal") => {
-    setTerminalOutput((prev) => [...prev, { text, type }]);
   };
 
   const handleSubmit = (e) => {
@@ -34,21 +26,20 @@ const ContactTerminal = () => {
 
     // Validation
     if (!form.name.trim()) {
-      addToTerminal("ERROR: Name field is required", "error");
+      setStatusMessage({ text: "Please enter your name", type: "error" });
       return;
     }
     if (!form.email.trim()) {
-      addToTerminal("ERROR: Email field is required", "error");
+      setStatusMessage({ text: "Please enter your email", type: "error" });
       return;
     }
     if (!form.message.trim()) {
-      addToTerminal("ERROR: Message field is required", "error");
+      setStatusMessage({ text: "Please enter a message", type: "error" });
       return;
     }
 
     setLoading(true);
-    addToTerminal("$ Initializing email transmission...", "command");
-    addToTerminal("Connecting to email service...", "loading");
+    setStatusMessage({ text: "Sending message...", type: "loading" });
 
     emailjs
       .send(
@@ -66,21 +57,29 @@ const ContactTerminal = () => {
       .then(
         () => {
           setLoading(false);
-          addToTerminal("✓ Message sent successfully!", "success");
-          addToTerminal(`✓ From: ${form.name} <${form.email}>`, "success");
-          addToTerminal("✓ I'll get back to you as soon as possible.", "success");
+          setStatusMessage({
+            text: "Message sent successfully! I'll get back to you soon.",
+            type: "success"
+          });
 
           setForm({
             name: "",
             email: "",
             message: "",
           });
+
+          // Clear success message after 5 seconds
+          setTimeout(() => {
+            setStatusMessage({ text: "", type: "" });
+          }, 5000);
         },
         (error) => {
           setLoading(false);
           console.error(error);
-          addToTerminal("✗ ERROR: Failed to send message", "error");
-          addToTerminal("✗ Please try again or contact directly via email", "error");
+          setStatusMessage({
+            text: "Failed to send message. Please try again or contact via email.",
+            type: "error"
+          });
         }
       );
   };
@@ -97,19 +96,19 @@ const ContactTerminal = () => {
 
         <div className="mt-8 space-y-6">
           <div className="bento-box p-6">
-            <div className="font-mono text-blueprint text-xs mb-3 uppercase tracking-wider">
+            <div className="text-blueprint text-sm mb-3 font-semibold uppercase tracking-wider">
               Email
             </div>
             <a
               href="mailto:jewelnath.me@gmail.com"
-              className="font-mono text-white hover:text-blueprint-light transition-colors text-lg"
+              className="text-white hover:text-blueprint-light transition-colors text-lg"
             >
               jewelnath.me@gmail.com
             </a>
           </div>
 
           <div className="bento-box p-6">
-            <div className="font-mono text-blueprint text-xs mb-3 uppercase tracking-wider">
+            <div className="text-blueprint text-sm mb-3 font-semibold uppercase tracking-wider">
               Social Links
             </div>
             <div className="space-y-3">
@@ -117,7 +116,7 @@ const ContactTerminal = () => {
                 href="https://github.com/devjewel01"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-3 font-mono text-secondary hover:text-blueprint-light transition-colors"
+                className="flex items-center gap-3 text-secondary hover:text-white transition-colors"
               >
                 <span className="text-terminal-green">→</span>
                 <span>github.com/devjewel01</span>
@@ -126,7 +125,7 @@ const ContactTerminal = () => {
                 href="https://linkedin.com/in/jewel-nath"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-3 font-mono text-secondary hover:text-blueprint-light transition-colors"
+                className="flex items-center gap-3 text-secondary hover:text-white transition-colors"
               >
                 <span className="text-terminal-green">→</span>
                 <span>linkedin.com/in/jewel-nath</span>
@@ -135,129 +134,97 @@ const ContactTerminal = () => {
           </div>
 
           <div className="bento-box p-6">
-            <div className="font-mono text-blueprint text-xs mb-3 uppercase tracking-wider">
+            <div className="text-blueprint text-sm mb-3 font-semibold uppercase tracking-wider">
               Location
             </div>
-            <div className="font-sans text-secondary">
+            <div className="text-secondary">
               Cumilla, Bangladesh
             </div>
           </div>
         </div>
       </motion.div>
 
-      {/* Right side - Terminal Contact Form */}
+      {/* Right side - Modern Contact Form */}
       <motion.div
         variants={slideIn("right", "tween", 0.2, 1)}
         className="flex-1"
       >
-        <div className="terminal-window">
-          <div className="terminal-header">
-            <div className="terminal-dot red" />
-            <div className="terminal-dot yellow" />
-            <div className="terminal-dot green" />
-            <span className="ml-3 font-mono text-xs text-secondary">
-              contact@jewel-portfolio
-            </span>
-          </div>
+        <div className="bento-box p-8">
+          {/* Status Message */}
+          {statusMessage.text && (
+            <div className={`
+              mb-6 p-4 rounded-lg text-sm
+              ${statusMessage.type === "error" ? "bg-red-500/10 border border-red-500/30 text-red-400" : ""}
+              ${statusMessage.type === "success" ? "bg-terminal-green/10 border border-terminal-green/30 text-terminal-green" : ""}
+              ${statusMessage.type === "loading" ? "bg-blueprint/10 border border-blueprint/30 text-blueprint" : ""}
+            `}>
+              {statusMessage.text}
+            </div>
+          )}
 
-          <div className="p-6">
-            {/* Terminal Output */}
-            <div className="font-mono text-sm mb-6 space-y-1 max-h-[200px] overflow-y-auto">
-              {terminalOutput.map((line, index) => (
-                <div
-                  key={index}
-                  className={`
-                    ${line.type === "error" ? "text-red-400" : ""}
-                    ${line.type === "success" ? "text-terminal-green" : ""}
-                    ${line.type === "command" ? "text-blueprint" : ""}
-                    ${line.type === "info" ? "text-secondary" : ""}
-                    ${line.type === "loading" ? "text-blueprint/70" : ""}
-                    ${line.type === "divider" ? "text-blueprint/30" : ""}
-                  `}
-                >
-                  {line.text}
-                </div>
-              ))}
+          {/* Contact Form */}
+          <form ref={formRef} onSubmit={handleSubmit} className="space-y-6">
+            {/* Name Input */}
+            <div>
+              <label className="block text-sm text-secondary mb-2 font-semibold">
+                Name
+              </label>
+              <input
+                type="text"
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                placeholder="Enter your name"
+                className="w-full bg-tertiary/50 border border-white/10 rounded-lg px-4 py-3 text-white text-sm focus:outline-none focus:border-blueprint transition-all"
+              />
             </div>
 
-            {/* Contact Form */}
-            <form ref={formRef} onSubmit={handleSubmit} className="space-y-4">
-              {/* Name Input */}
-              <div>
-                <label className="flex items-center gap-2 font-mono text-sm text-secondary mb-2">
-                  <span className="text-terminal-green">$</span>
-                  <span>--name</span>
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={form.name}
-                  onChange={handleChange}
-                  placeholder="Enter your name"
-                  className="w-full bg-tertiary border border-blueprint/30 rounded px-4 py-3 text-white font-mono text-sm focus:outline-none focus:border-blueprint focus:shadow-terminal transition-all"
-                />
-              </div>
+            {/* Email Input */}
+            <div>
+              <label className="block text-sm text-secondary mb-2 font-semibold">
+                Email
+              </label>
+              <input
+                type="email"
+                name="email"
+                value={form.email}
+                onChange={handleChange}
+                placeholder="Enter your email"
+                className="w-full bg-tertiary/50 border border-white/10 rounded-lg px-4 py-3 text-white text-sm focus:outline-none focus:border-blueprint transition-all"
+              />
+            </div>
 
-              {/* Email Input */}
-              <div>
-                <label className="flex items-center gap-2 font-mono text-sm text-secondary mb-2">
-                  <span className="text-terminal-green">$</span>
-                  <span>--email</span>
-                </label>
-                <input
-                  type="email"
-                  name="email"
-                  value={form.email}
-                  onChange={handleChange}
-                  placeholder="Enter your email"
-                  className="w-full bg-tertiary border border-blueprint/30 rounded px-4 py-3 text-white font-mono text-sm focus:outline-none focus:border-blueprint focus:shadow-terminal transition-all"
-                />
-              </div>
+            {/* Message Input */}
+            <div>
+              <label className="block text-sm text-secondary mb-2 font-semibold">
+                Message
+              </label>
+              <textarea
+                rows={7}
+                name="message"
+                value={form.message}
+                onChange={handleChange}
+                placeholder="Type your message here..."
+                className="w-full bg-tertiary/50 border border-white/10 rounded-lg px-4 py-3 text-white text-sm focus:outline-none focus:border-blueprint transition-all resize-none"
+              />
+            </div>
 
-              {/* Message Input */}
-              <div>
-                <label className="flex items-center gap-2 font-mono text-sm text-secondary mb-2">
-                  <span className="text-terminal-green">$</span>
-                  <span>--message</span>
-                </label>
-                <textarea
-                  rows={7}
-                  name="message"
-                  value={form.message}
-                  onChange={handleChange}
-                  placeholder="Type your message here..."
-                  className="w-full bg-tertiary border border-blueprint/30 rounded px-4 py-3 text-white font-mono text-sm focus:outline-none focus:border-blueprint focus:shadow-terminal transition-all resize-none"
-                />
-              </div>
-
-              {/* Submit Button */}
-              <button
-                type="submit"
-                disabled={loading}
-                className={`
-                  w-full font-mono text-sm py-3 rounded border transition-all
-                  ${
-                    loading
-                      ? "bg-blueprint/20 border-blueprint/40 text-blueprint/60 cursor-not-allowed"
-                      : "bg-blueprint/10 border-blueprint text-blueprint hover:bg-blueprint/20 hover:shadow-blueprint"
-                  }
-                `}
-              >
-                {loading ? (
-                  <span className="flex items-center justify-center gap-2">
-                    <span className="animate-pulse">●</span>
-                    <span>Sending...</span>
-                    <span className="animate-pulse">●</span>
-                  </span>
-                ) : (
-                  <span className="flex items-center justify-center gap-2">
-                    <span>$</span>
-                    <span>send_message.sh</span>
-                  </span>
-                )}
-              </button>
-            </form>
-          </div>
+            {/* Submit Button */}
+            <button
+              type="submit"
+              disabled={loading}
+              className={`
+                w-full text-sm py-3 rounded-lg border transition-all font-semibold
+                ${
+                  loading
+                    ? "bg-blueprint/20 border-blueprint/40 text-blueprint/60 cursor-not-allowed"
+                    : "bg-blueprint/10 border-blueprint text-blueprint hover:bg-blueprint/20"
+                }
+              `}
+            >
+              {loading ? "Sending..." : "Send Message"}
+            </button>
+          </form>
         </div>
       </motion.div>
     </div>

--- a/src/features/experience/Experience.jsx
+++ b/src/features/experience/Experience.jsx
@@ -109,57 +109,16 @@ const Experience = () => {
         </motion.p>
       </div>
 
-      {/* Terminal Window Wrapper */}
-      <motion.div
-        variants={fadeIn("up", "spring", 0.2, 0.75)}
-        className="relative border border-white/10 rounded-xl overflow-hidden bg-black/30 backdrop-blur-sm shadow-2xl"
-      >
-        {/* Terminal Header */}
-        <div className="bg-tertiary border-b border-white/10 px-4 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            {/* Terminal Buttons */}
-            <div className="flex gap-2">
-              <div className="w-3 h-3 rounded-full bg-red-500/80 hover:bg-red-500 transition-colors cursor-pointer" />
-              <div className="w-3 h-3 rounded-full bg-yellow-500/80 hover:bg-yellow-500 transition-colors cursor-pointer" />
-              <div className="w-3 h-3 rounded-full bg-green-500/80 hover:bg-green-500 transition-colors cursor-pointer" />
-            </div>
-            {/* Terminal Title */}
-            <span className="ml-3 text-secondary/70 font-mono text-sm">
-              work_experience.sh
-            </span>
-          </div>
-          <div className="flex items-center gap-2 text-secondary/50 text-xs font-mono">
-            <span className="hidden sm:inline">zsh</span>
-            <span>●</span>
-            <span className="hidden sm:inline">{experiences.length} roles</span>
-          </div>
-        </div>
-
-        {/* Command Prompt Line */}
-        <div className="bg-black/20 border-b border-white/5 px-6 py-3 font-mono text-sm">
-          <span className="text-terminal-green">➜</span>
-          <span className="text-blueprint ml-2">~/portfolio</span>
-          <span className="text-secondary/50 ml-2">cat work_experience.sh</span>
-          <span className="animate-pulse ml-1">▊</span>
-        </div>
-
-        {/* Experience grid layout */}
-        <div className="p-6 grid grid-cols-1 lg:grid-cols-2 gap-6 md:gap-8">
-          {experiences.map((experience, index) => (
-            <ExperienceCard
-              key={`experience-${index}`}
-              experience={experience}
-              index={index}
-            />
-          ))}
-        </div>
-
-        {/* Terminal Footer */}
-        <div className="bg-black/20 border-t border-white/5 px-6 py-2 font-mono text-xs text-secondary/50 flex items-center justify-between">
-          <span>{experiences.length} roles loaded successfully</span>
-          <span className="hidden sm:inline">Press ESC to exit</span>
-        </div>
-      </motion.div>
+      {/* Modern Card Grid Layout */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 md:gap-8">
+        {experiences.map((experience, index) => (
+          <ExperienceCard
+            key={`experience-${index}`}
+            experience={experience}
+            index={index}
+          />
+        ))}
+      </div>
     </>
   );
 };

--- a/src/features/home/HeroBento.jsx
+++ b/src/features/home/HeroBento.jsx
@@ -155,18 +155,14 @@ const HeroBento = () => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8 }}
         >
-          {/* Terminal-style greeting */}
+          {/* Modern greeting */}
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.2 }}
-            className="font-mono text-terminal-green text-xs md:text-sm mb-8 flex items-center justify-center gap-2"
+            className="text-blueprint text-sm md:text-base mb-8 font-semibold tracking-wide"
           >
-            <span className="text-blueprint">jewel@portfolio</span>
-            <span className="text-secondary">:</span>
-            <span className="text-white">~</span>
-            <span className="text-terminal-green">$</span>
-            <span className="text-secondary">./introduce.sh</span>
+            Welcome to My Portfolio
           </motion.div>
 
           {/* Name */}
@@ -191,7 +187,7 @@ const HeroBento = () => {
           >
             <p className="text-lg md:text-2xl text-secondary flex items-center justify-center">
               {displayText}
-              <span className="terminal-cursor ml-1"></span>
+              <span className="inline-block w-0.5 h-6 md:h-8 bg-blueprint ml-2 animate-pulse"></span>
             </p>
           </motion.div>
 

--- a/src/features/projects/ProjectsBlueprint.jsx
+++ b/src/features/projects/ProjectsBlueprint.jsx
@@ -115,53 +115,12 @@ const ProjectsBlueprint = () => {
         </motion.p>
       </div>
 
-      {/* Terminal Window Wrapper */}
-      <motion.div
-        variants={fadeIn("up", "spring", 0.2, 0.75)}
-        className="relative border border-white/10 rounded-xl overflow-hidden bg-black/30 backdrop-blur-sm shadow-2xl"
-      >
-        {/* Terminal Header */}
-        <div className="bg-tertiary border-b border-white/10 px-4 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            {/* Terminal Buttons */}
-            <div className="flex gap-2">
-              <div className="w-3 h-3 rounded-full bg-red-500/80 hover:bg-red-500 transition-colors cursor-pointer" />
-              <div className="w-3 h-3 rounded-full bg-yellow-500/80 hover:bg-yellow-500 transition-colors cursor-pointer" />
-              <div className="w-3 h-3 rounded-full bg-green-500/80 hover:bg-green-500 transition-colors cursor-pointer" />
-            </div>
-            {/* Terminal Title */}
-            <span className="ml-3 text-secondary/70 font-mono text-sm">
-              projects.sh
-            </span>
-          </div>
-          <div className="flex items-center gap-2 text-secondary/50 text-xs font-mono">
-            <span className="hidden sm:inline">zsh</span>
-            <span>●</span>
-            <span className="hidden sm:inline">{projects.length} projects</span>
-          </div>
-        </div>
-
-        {/* Command Prompt Line */}
-        <div className="bg-black/20 border-b border-white/5 px-6 py-3 font-mono text-sm">
-          <span className="text-terminal-green">➜</span>
-          <span className="text-blueprint ml-2">~/portfolio</span>
-          <span className="text-secondary/50 ml-2">ls -la projects/</span>
-          <span className="animate-pulse ml-1">▊</span>
-        </div>
-
-        {/* Projects grid layout */}
-        <div className="p-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {projects.map((project, index) => (
-            <ProjectCard key={`project-${index}`} index={index} {...project} />
-          ))}
-        </div>
-
-        {/* Terminal Footer */}
-        <div className="bg-black/20 border-t border-white/5 px-6 py-2 font-mono text-xs text-secondary/50 flex items-center justify-between">
-          <span>{projects.length} projects loaded successfully</span>
-          <span className="hidden sm:inline">Press ESC to exit</span>
-        </div>
-      </motion.div>
+      {/* Modern Card Grid Layout */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {projects.map((project, index) => (
+          <ProjectCard key={`project-${index}`} index={index} {...project} />
+        ))}
+      </div>
     </>
   );
 };

--- a/src/features/tech/TechTerminal.jsx
+++ b/src/features/tech/TechTerminal.jsx
@@ -48,116 +48,72 @@ const TechTerminal = () => {
         Tech stack powering enterprise software, robotics automation, and AI-driven solutions.
       </motion.p>
 
-      {/* Terminal Window Wrapper */}
-      <motion.div
-        variants={fadeIn("up", "spring", 0.2, 0.75)}
-        className="relative border border-white/10 rounded-xl overflow-hidden bg-black/30 backdrop-blur-sm shadow-2xl"
-      >
-        {/* Terminal Header */}
-        <div className="bg-tertiary border-b border-white/10 px-4 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            {/* Terminal Buttons */}
-            <div className="flex gap-2">
-              <div className="w-3 h-3 rounded-full bg-red-500/80 hover:bg-red-500 transition-colors cursor-pointer" />
-              <div className="w-3 h-3 rounded-full bg-yellow-500/80 hover:bg-yellow-500 transition-colors cursor-pointer" />
-              <div className="w-3 h-3 rounded-full bg-green-500/80 hover:bg-green-500 transition-colors cursor-pointer" />
-            </div>
-            {/* Terminal Title */}
-            <span className="ml-3 text-secondary/70 font-mono text-sm">
-              tech_skills.sh
-            </span>
-          </div>
-          <div className="flex items-center gap-2 text-secondary/50 text-xs font-mono">
-            <span className="hidden sm:inline">zsh</span>
-            <span>●</span>
-            <span className="hidden sm:inline">5 modules</span>
-          </div>
-        </div>
+      {/* Modern Card Grid Layout */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 auto-rows-auto">
+        {Object.entries(techCategories).map(([key, { label, techs, color }], catIndex) => (
+          <motion.div
+            key={key}
+            variants={fadeIn("up", "spring", 0.2 + catIndex * 0.1, 0.75)}
+            className={`
+              bento-box group relative overflow-hidden
+              ${key === 'backend' ? 'lg:col-span-2' : ''}
+              ${key === 'learning' ? 'md:col-span-2 lg:col-span-1' : ''}
+            `}
+          >
+            {/* Animated Background Gradient */}
+            <div className={`absolute inset-0 opacity-0 group-hover:opacity-5 transition-opacity duration-500 bg-gradient-to-br ${color.replace('text-', 'from-')} to-transparent`} />
 
-        {/* Command Prompt Line */}
-        <div className="bg-black/20 border-b border-white/5 px-6 py-3 font-mono text-sm">
-          <span className="text-terminal-green">➜</span>
-          <span className="text-blueprint ml-2">~/portfolio</span>
-          <span className="text-secondary/50 ml-2">cat tech_skills.sh</span>
-          <span className="animate-pulse ml-1">▊</span>
-        </div>
-
-        {/* Bento Grid Layout - Terminal Style */}
-        <div className="p-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-auto">
-          {Object.entries(techCategories).map(([key, { label, techs, color }], catIndex) => (
-            <motion.div
-              key={key}
-              variants={fadeIn("up", "spring", 0.2 + catIndex * 0.1, 0.75)}
-              className={`
-                bento-box group relative overflow-hidden
-                ${key === 'backend' ? 'lg:col-span-2' : ''}
-                ${key === 'learning' ? 'md:col-span-2 lg:col-span-1' : ''}
-              `}
-            >
-              {/* Animated Background Gradient */}
-              <div className={`absolute inset-0 opacity-0 group-hover:opacity-5 transition-opacity duration-500 bg-gradient-to-br ${color.replace('text-', 'from-')} to-transparent`} />
-
-              {/* Card Content */}
-              <div className="relative p-6 h-full flex flex-col">
-                {/* Category Header with Terminal Style */}
-                <div className="flex items-center gap-3 mb-4">
-                  <div className={`w-1 h-8 ${color.replace('text-', 'bg-')} rounded-full`} />
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <span className={`${color} text-xs font-mono`}>$</span>
-                      <h3 className={`${color} font-mono text-sm font-semibold tracking-wider`}>
-                        {label.toUpperCase()}
-                      </h3>
-                    </div>
-                    <div className="flex items-center gap-2 mt-1">
-                      <span className="text-secondary/50 text-xs font-mono">[{techs.length} techs]</span>
-                      <div className={`h-px w-8 ${color.replace('text-', 'bg-')} opacity-30`} />
-                    </div>
+            {/* Card Content */}
+            <div className="relative p-6 h-full flex flex-col">
+              {/* Category Header */}
+              <div className="flex items-center gap-3 mb-4">
+                <div className={`w-1 h-8 ${color.replace('text-', 'bg-')} rounded-full`} />
+                <div>
+                  <h3 className={`${color} text-lg font-semibold tracking-wide`}>
+                    {label}
+                  </h3>
+                  <div className="flex items-center gap-2 mt-1">
+                    <span className="text-secondary/50 text-xs">{techs.length} technologies</span>
+                    <div className={`h-px w-8 ${color.replace('text-', 'bg-')} opacity-30`} />
                   </div>
                 </div>
-
-                {/* Technologies as Floating Pills */}
-                <div className="flex flex-wrap gap-2">
-                  {techs.map((tech, index) => (
-                    <motion.div
-                      key={tech}
-                      initial={{ opacity: 0, scale: 0.8 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      transition={{ delay: 0.3 + catIndex * 0.1 + index * 0.05 }}
-                      whileHover={{ scale: 1.05, y: -2 }}
-                      className={`
-                        relative px-3 py-1.5 rounded
-                        bg-tertiary/50 backdrop-blur-sm
-                        border border-white/10
-                        hover:border-${color.replace('text-', '')}/50
-                        transition-all duration-300
-                        cursor-pointer
-                        group/pill
-                      `}
-                    >
-                      <span className={`${color.replace('text-', 'text-')}/70 text-sm font-mono group-hover/pill:${color} transition-colors`}>
-                        {tech}
-                      </span>
-
-                      {/* Hover glow effect */}
-                      <div className={`absolute inset-0 rounded opacity-0 group-hover/pill:opacity-20 transition-opacity ${color.replace('text-', 'bg-')} blur-md -z-10`} />
-                    </motion.div>
-                  ))}
-                </div>
-
-                {/* Corner Accent */}
-                <div className={`absolute top-0 right-0 w-16 h-16 ${color.replace('text-', 'bg-')} opacity-5 blur-2xl rounded-full -translate-y-8 translate-x-8 group-hover:opacity-10 transition-opacity`} />
               </div>
-            </motion.div>
-          ))}
-        </div>
 
-        {/* Terminal Footer */}
-        <div className="bg-black/20 border-t border-white/5 px-6 py-2 font-mono text-xs text-secondary/50 flex items-center justify-between">
-          <span>5 categories loaded successfully</span>
-          <span className="hidden sm:inline">Press ESC to exit</span>
-        </div>
-      </motion.div>
+              {/* Technologies as Floating Pills */}
+              <div className="flex flex-wrap gap-2">
+                {techs.map((tech, index) => (
+                  <motion.div
+                    key={tech}
+                    initial={{ opacity: 0, scale: 0.8 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ delay: 0.3 + catIndex * 0.1 + index * 0.05 }}
+                    whileHover={{ scale: 1.05, y: -2 }}
+                    className={`
+                      relative px-3 py-1.5 rounded
+                      bg-tertiary/50 backdrop-blur-sm
+                      border border-white/10
+                      hover:border-${color.replace('text-', '')}/50
+                      transition-all duration-300
+                      cursor-pointer
+                      group/pill
+                    `}
+                  >
+                    <span className={`${color.replace('text-', 'text-')}/70 text-sm group-hover/pill:${color} transition-colors`}>
+                      {tech}
+                    </span>
+
+                    {/* Hover glow effect */}
+                    <div className={`absolute inset-0 rounded opacity-0 group-hover/pill:opacity-20 transition-opacity ${color.replace('text-', 'bg-')} blur-md -z-10`} />
+                  </motion.div>
+                ))}
+              </div>
+
+              {/* Corner Accent */}
+              <div className={`absolute top-0 right-0 w-16 h-16 ${color.replace('text-', 'bg-')} opacity-5 blur-2xl rounded-full -translate-y-8 translate-x-8 group-hover:opacity-10 transition-opacity`} />
+            </div>
+          </motion.div>
+        ))}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
- Convert TerminalNavbar to modern clean navbar with gradient branding
- Remove terminal window wrappers from all sections (Tech, Projects, Experience)
- Replace terminal-style contact form with modern card-based form
- Remove terminal command syntax ($ cd, cat, etc.) from navigation
- Update HeroBento to use modern greeting instead of terminal prompt
- Maintain unified bento-box card aesthetic across all sections
- Keep modern hover effects and smooth transitions